### PR TITLE
Rename users database

### DIFF
--- a/dev-learning/Controllers/UsersController.cs
+++ b/dev-learning/Controllers/UsersController.cs
@@ -22,14 +22,14 @@ namespace dev_learning.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<User>>> GetUsers()
         {
-            return await _context.Users.ToListAsync();
+            return await _context.User.ToListAsync();
         }
 
         // GET: api/Users/5
         [HttpGet("{id}")]
         public async Task<ActionResult<User>> GetUser(int id)
         {
-            var user = await _context.Users.FindAsync(id);
+            var user = await _context.User.FindAsync(id);
 
             if (user == null)
             {
@@ -72,7 +72,7 @@ namespace dev_learning.Controllers
         [HttpPost]
         public async Task<ActionResult<User>> PostUser(User user)
         {
-            _context.Users.Add(user);
+            _context.User.Add(user);
             await _context.SaveChangesAsync();
             return CreatedAtAction("GetUser", new { id = user.id }, user);
         }
@@ -81,13 +81,13 @@ namespace dev_learning.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult<User>> DeleteUser(int id)
         {
-            var user = await _context.Users.FindAsync(id);
+            var user = await _context.User.FindAsync(id);
             if (user == null)
             {
                 return NotFound();
             }
 
-            _context.Users.Remove(user);
+            _context.User.Remove(user);
             await _context.SaveChangesAsync();
 
             return user;
@@ -97,7 +97,7 @@ namespace dev_learning.Controllers
         [HttpPost("login")]
         public async Task<IActionResult> Login(AuthRequest authRequest)
         {
-            var users = await _context.Users.ToListAsync();
+            var users = await _context.User.ToListAsync();
             var isUserValid = users.Exists(user => user.email == authRequest.email && user.password == authRequest.password);
 
             if (isUserValid)
@@ -110,7 +110,7 @@ namespace dev_learning.Controllers
 
         private bool UserExists(int id)
         {
-            return _context.Users.Any(e => e.id == id);
+            return _context.User.Any(e => e.id == id);
         }
     }
 }

--- a/dev-learning/Controllers/UsersController.cs
+++ b/dev-learning/Controllers/UsersController.cs
@@ -22,14 +22,14 @@ namespace dev_learning.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<User>>> GetUsers()
         {
-            return await _context.User.ToListAsync();
+            return await _context.Users.ToListAsync();
         }
 
         // GET: api/Users/5
         [HttpGet("{id}")]
         public async Task<ActionResult<User>> GetUser(int id)
         {
-            var user = await _context.User.FindAsync(id);
+            var user = await _context.Users.FindAsync(id);
 
             if (user == null)
             {
@@ -72,7 +72,7 @@ namespace dev_learning.Controllers
         [HttpPost]
         public async Task<ActionResult<User>> PostUser(User user)
         {
-            _context.User.Add(user);
+            _context.Users.Add(user);
             await _context.SaveChangesAsync();
             return CreatedAtAction("GetUser", new { id = user.id }, user);
         }
@@ -81,13 +81,13 @@ namespace dev_learning.Controllers
         [HttpDelete("{id}")]
         public async Task<ActionResult<User>> DeleteUser(int id)
         {
-            var user = await _context.User.FindAsync(id);
+            var user = await _context.Users.FindAsync(id);
             if (user == null)
             {
                 return NotFound();
             }
 
-            _context.User.Remove(user);
+            _context.Users.Remove(user);
             await _context.SaveChangesAsync();
 
             return user;
@@ -97,7 +97,7 @@ namespace dev_learning.Controllers
         [HttpPost("login")]
         public async Task<IActionResult> Login(AuthRequest authRequest)
         {
-            var users = await _context.User.ToListAsync();
+            var users = await _context.Users.ToListAsync();
             var isUserValid = users.Exists(user => user.email == authRequest.email && user.password == authRequest.password);
 
             if (isUserValid)
@@ -110,7 +110,7 @@ namespace dev_learning.Controllers
 
         private bool UserExists(int id)
         {
-            return _context.User.Any(e => e.id == id);
+            return _context.Users.Any(e => e.id == id);
         }
     }
 }

--- a/dev-learning/Extensions/ModelBuilderExtensions.cs
+++ b/dev-learning/Extensions/ModelBuilderExtensions.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace dev_learning.Extensions
+{
+    public static class ModelBuilderExtensions
+    {
+        public static void RemovePluralizingTableNameConvention(this ModelBuilder modelBuilder)
+        {
+            foreach (Microsoft.EntityFrameworkCore.Metadata.IMutableEntityType entity in modelBuilder.Model.GetEntityTypes())
+            {
+                entity.SetTableName(entity.DisplayName());
+            }
+        }
+    }
+}

--- a/dev-learning/Models/UserContext.cs
+++ b/dev-learning/Models/UserContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Configuration;
+﻿using dev_learning.Extensions;
 using Microsoft.EntityFrameworkCore;
 namespace dev_learning.Models
 {
@@ -9,7 +9,11 @@ namespace dev_learning.Models
         {
         }
 
-        public DbSet<User> User { get; set; }
+        public DbSet<User> Users { get; set; }
 
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.RemovePluralizingTableNameConvention();
+        }
     }
 }

--- a/dev-learning/Models/UserContext.cs
+++ b/dev-learning/Models/UserContext.cs
@@ -9,7 +9,7 @@ namespace dev_learning.Models
         {
         }
 
-        public DbSet<User> Users { get; set; }
+        public DbSet<User> User { get; set; }
 
     }
 }


### PR DESCRIPTION
(...) When you work with Entity Framework Code First approach, you are creating your database tables from your model classes. Usually Entity Framework will create tables with Pluralized names. that means if you have a model class called PhoneNumber, Entity framework will create a table for this class called “PhoneNumbers“. (...) 
I started getting an internal server error on every API request after we renamed `public DbSet<User> User { get; set; }` to `public DbSet<User> Users { get; set; }` . I guess it has something to do with the logic that we don't see so I renamed it back to User and everything works fine.